### PR TITLE
Avoid having one filter instance multiple times in child filters collection

### DIFF
--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractAggregatingFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractAggregatingFilter.java
@@ -54,7 +54,7 @@ public abstract class AbstractAggregatingFilter
     @Override
     public ProjectRelationshipFilter getChildFilter( final ProjectRelationship<?> parent )
     {
-        final List<ProjectRelationshipFilter> childFilters = new ArrayList<ProjectRelationshipFilter>();
+        final Set<ProjectRelationshipFilter> childFilters = new HashSet<ProjectRelationshipFilter>();
         for ( final ProjectRelationshipFilter filter : getFilters() )
         {
             //            if ( filter.accept( parent ) )
@@ -72,7 +72,7 @@ public abstract class AbstractAggregatingFilter
         return newChildFilter( childFilters );
     }
 
-    protected abstract AbstractAggregatingFilter newChildFilter( List<ProjectRelationshipFilter> childFilters );
+    protected abstract AbstractAggregatingFilter newChildFilter( Collection<ProjectRelationshipFilter> childFilters );
 
     @Override
     public Iterator<ProjectRelationshipFilter> iterator()

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AndFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AndFilter.java
@@ -51,7 +51,7 @@ public class AndFilter
     }
 
     @Override
-    protected AbstractAggregatingFilter newChildFilter( final List<ProjectRelationshipFilter> childFilters )
+    protected AbstractAggregatingFilter newChildFilter( final Collection<ProjectRelationshipFilter> childFilters )
     {
         if ( !filtersEqual( childFilters ) )
         {

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/OrFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/OrFilter.java
@@ -54,7 +54,7 @@ public class OrFilter
     }
 
     @Override
-    protected AbstractAggregatingFilter newChildFilter( final List<ProjectRelationshipFilter> childFilters )
+    protected AbstractAggregatingFilter newChildFilter( final Collection<ProjectRelationshipFilter> childFilters )
     {
         if ( !filtersEqual( childFilters ) )
         {


### PR DESCRIPTION
Usage of ArrayList in an aggregating filter allows having the same instance of
a child filter multiple times without any effect. Problem with that is that it
can create very rich filter tree that slows down getting child filters. Changing
this led to reduction of the time needed to traverse a graph from tens of
minutes (and still waiting for a result) to less than a second.
