### PR TITLE
Fix problems with comparing and hashing objects

### DIFF
--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/Neo4jGraphPath.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/Neo4jGraphPath.java
@@ -171,6 +171,8 @@ public class Neo4jGraphPath
     {
         final int prime = 31;
         int result = 1;
+        result = prime * result + Long.valueOf( startNode ).hashCode();
+        result = prime * result + Long.valueOf( endNode ).hashCode();
         result = prime * result + Arrays.hashCode( relationships );
         return result;
     }
@@ -191,6 +193,14 @@ public class Neo4jGraphPath
             return false;
         }
         final Neo4jGraphPath other = (Neo4jGraphPath) obj;
+        if ( startNode != other.startNode )
+        {
+            return false;
+        }
+        if ( endNode != other.endNode )
+        {
+            return false;
+        }
         if ( !Arrays.equals( relationships, other.relationships ) )
         {
             return false;

--- a/identities/src/main/java/org/commonjava/maven/atlas/ident/ref/ProjectRef.java
+++ b/identities/src/main/java/org/commonjava/maven/atlas/ident/ref/ProjectRef.java
@@ -158,7 +158,7 @@ public class ProjectRef
             comp = artifactId.compareTo( o.artifactId );
         }
 
-        return 0;
+        return comp;
     }
 
     public boolean matches( final ProjectRef ref )


### PR DESCRIPTION
This ProjectRef problem causes that if we pass more than one root in urlmap, the read HashSet gets converted to TreeSet in GraphDescription.setRoots(). TreeSet uses compareTo method to determine if the value is already present in the set which resulted in usage of the first root only no matter how many of them were specified.
Similar problem followed in Neo4jGraphPath, because paths to roots themselves with empty relationships were all considered to be the same so only the first one was used and the rest was thrown away.