### PR TITLE
Ensure having only 1 instance of ManagedDependencyMutator

### DIFF
--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/ViewParams.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/ViewParams.java
@@ -155,7 +155,7 @@ public class ViewParams
 
     public GraphMutator getMutator()
     {
-        return mutator == null ? new ManagedDependencyMutator() : mutator;
+        return mutator == null ? ManagedDependencyMutator.INSTANCE : mutator;
     }
 
     public ProjectRelationshipFilter getFilter()
@@ -449,7 +449,7 @@ public class ViewParams
             this.properties = new HashMap<String, String>();
             this.selections = new HashMap<ProjectRef, ProjectVersionRef>();
             this.filter = AnyFilter.INSTANCE;
-            this.mutator = new ManagedDependencyMutator();
+            this.mutator = ManagedDependencyMutator.INSTANCE;
         }
 
         public Builder( final String workspaceId, final Collection<ProjectVersionRef> roots )
@@ -461,7 +461,7 @@ public class ViewParams
             this.properties = new HashMap<String, String>();
             this.selections = new HashMap<ProjectRef, ProjectVersionRef>();
             this.filter = AnyFilter.INSTANCE;
-            this.mutator = new ManagedDependencyMutator();
+            this.mutator = ManagedDependencyMutator.INSTANCE;
         }
 
         public Builder( final ViewParams params )

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/mutate/ManagedDependencyMutator.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/mutate/ManagedDependencyMutator.java
@@ -27,8 +27,17 @@ public class ManagedDependencyMutator
     implements GraphMutator
 {
 
+    public static final ManagedDependencyMutator INSTANCE = new ManagedDependencyMutator();
+
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Hidden constructor.
+     */
+    private ManagedDependencyMutator()
+    {
+    }
+    
     @Override
     public ProjectRelationship<?, ?> selectFor( final ProjectRelationship<?, ?> rel, final GraphPath<?> path,
                                              final RelationshipGraphConnection connection, final ViewParams params )

--- a/tck/src/main/java/org/commonjava/maven/atlas/tck/graph/manip/RelationshipGraph_StoreAndVerifyInView_TCK.java
+++ b/tck/src/main/java/org/commonjava/maven/atlas/tck/graph/manip/RelationshipGraph_StoreAndVerifyInView_TCK.java
@@ -53,7 +53,7 @@ public class RelationshipGraph_StoreAndVerifyInView_TCK
         final ProjectVersionRef d2 = new SimpleProjectVersionRef( "g", "d2", "2" );
 
         final RelationshipGraph graph =
-            openGraph( new ViewParams( newWorkspaceId(), new DependencyFilter(), new ManagedDependencyMutator(), gav ),
+            openGraph( new ViewParams( newWorkspaceId(), new DependencyFilter(), ManagedDependencyMutator.INSTANCE, gav ),
                        true );
 
         /* @formatter:off */


### PR DESCRIPTION
The class has only 2 fields - longId and shortId, both made of the class name.
So there is no point in creating more than 1 instance.