### PR TITLE
Support detaching of AbstractNeoProjectRelationship instances

### DIFF
--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
@@ -63,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -232,12 +233,34 @@ public final class Conversions
         return refs;
     }
 
-    public static List<ProjectRelationship<?, ?>> convertToDetachedRelationships( final Iterable<Relationship> relationships )
+    /**
+     * Converts an iterable of relationships to project relationships detached from database.
+     *
+     * @param relationships iterable of {@link AbstractNeoProjectRelationship} or {@link Relationship}
+     * @return list of detached relationships
+     * @throws IllegalArgumentException if an iterable of unsupported classes is passed
+     */
+    public static List<ProjectRelationship<?, ?>> convertToDetachedRelationships( final Iterable<?> relationships )
     {
         final List<ProjectRelationship<?, ?>> rels = new ArrayList<ProjectRelationship<?, ?>>();
-        for ( final Relationship relationship : relationships )
+        Iterator<?> iterator = relationships.iterator();
+        while ( iterator.hasNext() )
         {
-            final AbstractNeoProjectRelationship<?, ?, ?> rel = Conversions.toProjectRelationship( relationship );
+            final AbstractNeoProjectRelationship<?, ?, ?> rel;
+            Object next = iterator.next();
+            if ( next instanceof AbstractNeoProjectRelationship )
+            {
+                rel = ( AbstractNeoProjectRelationship<?, ?, ?>) next;
+            }
+            else if ( next instanceof AbstractNeoProjectRelationship )
+            {
+                rel = Conversions.toProjectRelationship( ( Relationship ) next );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Relationship class " + next.getClass().getCanonicalName()
+                                                  + " cannot be converted to detached relationship." );
+            }
             if ( rel != null )
             {
                 rels.add( rel.detach() );

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
@@ -252,7 +252,7 @@ public final class Conversions
             {
                 rel = ( AbstractNeoProjectRelationship<?, ?, ?>) next;
             }
-            else if ( next instanceof AbstractNeoProjectRelationship )
+            else if ( next instanceof Relationship )
             {
                 rel = Conversions.toProjectRelationship( ( Relationship ) next );
             }


### PR DESCRIPTION
Current implementation of convertToDetachedRelationships was only able to process iterables of Relationship instances, where each instance was converted to AbstractNeoProjectRelationship and then called detach() on it. The new implementation basically drops the generic type of Iterable to allow passing of both required classes. Having 2 overloaded methods is not possible because the only difference between those is the generic type and compiler fails. Adding a dummy parameter to differentiate the method API does not seem like a good practice to me too.