### PR TITLE
Fix relationship deserialization

### DIFF
--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/FileNeo4JGraphConnection.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/FileNeo4JGraphConnection.java
@@ -94,8 +94,8 @@ public class FileNeo4JGraphConnection
 
     /* @formatter:off */
 //    private static final String CYPHER_SELECTION_RETRIEVAL = String.format(
-//        "CYPHER 1.8 START a=node({roots}) " 
-//            + "\nMATCH p1=(a)-[:{}*1..]->(s), " 
+//        "CYPHER 1.8 START a=node({roots}) "
+//            + "\nMATCH p1=(a)-[:{}*1..]->(s), "
 //            + "\n    p2=(a)-[:{}*1..]->(v) "
 //            + "\nWITH v, s, last(relationships(p1)) as r1, last(relationships(p2)) as r2 "
 //            + "\nWHERE v.{} = s.{} "
@@ -107,13 +107,13 @@ public class FileNeo4JGraphConnection
 //            + "\n    AND any(x in r2.{} "
 //            + "\n          WHERE x IN {roots}) "
 //            + "\nRETURN r1,r2,v,s",
-//        GRAPH_ATLAS_TYPES_CLAUSE, GRAPH_ATLAS_TYPES_CLAUSE, 
-//        Conversions.GROUP_ID, Conversions.GROUP_ID, 
-//        Conversions.ARTIFACT_ID, Conversions.ARTIFACT_ID, 
-//        Conversions.SELECTED_FOR, Conversions.SELECTED_FOR, 
+//        GRAPH_ATLAS_TYPES_CLAUSE, GRAPH_ATLAS_TYPES_CLAUSE,
+//        Conversions.GROUP_ID, Conversions.GROUP_ID,
+//        Conversions.ARTIFACT_ID, Conversions.ARTIFACT_ID,
+//        Conversions.SELECTED_FOR, Conversions.SELECTED_FOR,
 //        Conversions.DESELECTED_FOR, Conversions.DESELECTED_FOR
 //    );
-    
+
     /* @formatter:on */
 
     private boolean closed = false;
@@ -531,7 +531,7 @@ public class FileNeo4JGraphConnection
         return createdRelationshipsMap;
     }
 
-    private void insertRelationshipBatch( List<ProjectRelationship<?, ?>> rels, Map<Long, ProjectRelationship<?, ?>> createdRelationshipsMap )
+    private void insertRelationshipBatch( final List<ProjectRelationship<?, ?>> rels, final Map<Long, ProjectRelationship<?, ?>> createdRelationshipsMap )
     {
         final Transaction tx = graph.beginTx();
         try
@@ -2407,9 +2407,9 @@ public class FileNeo4JGraphConnection
             {
                 node = newProjectNode( ref );
             }
-            
+
             Conversions.storeError( node, error );
-            
+
             tx.success();
         }
         finally

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/Conversions.java
@@ -588,9 +588,6 @@ public final class Conversions
             return null;
         }
 
-        final String type = getStringProperty( TYPE, rel );
-        final String classifier = getStringProperty( CLASSIFIER, rel );
-
         return new NeoArtifactRef( ref, new NeoTypeAndClassifier( rel ) );
     }
 

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoArtifactRef.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoArtifactRef.java
@@ -15,8 +15,6 @@
  */
 package org.commonjava.maven.atlas.graph.spi.neo4j.model;
 
-import static org.commonjava.maven.atlas.graph.spi.neo4j.model.NeoIdentityUtils.getBooleanProperty;
-import org.commonjava.maven.atlas.graph.spi.neo4j.io.Conversions;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.InvalidRefException;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
@@ -74,10 +72,10 @@ public class NeoArtifactRef<T extends ArtifactRef>
         this.tc = tc;
     }
 
-    public NeoArtifactRef( final Node node )
+    public NeoArtifactRef( final Node node, final NeoTypeAndClassifier tc )
     {
         super( node );
-        this.tc = new NeoTypeAndClassifier( node );
+        this.tc = tc;
     }
 
     public NeoArtifactRef( final String groupId, final String artifactId, final String versionSpec, final String type,

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoDependencyRelationship.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoDependencyRelationship.java
@@ -104,7 +104,7 @@ public final class NeoDependencyRelationship
     @Override
     public ArtifactRef getTarget()
     {
-        return target == null ? new NeoArtifactRef( rel.getEndNode() ) : target;
+        return target == null ? new NeoArtifactRef( rel.getEndNode(), new NeoTypeAndClassifier( rel ) ) : target;
     }
 
     @Override

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoPluginDependencyRelationship.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoPluginDependencyRelationship.java
@@ -110,7 +110,7 @@ public final class NeoPluginDependencyRelationship
     @Override
     public ArtifactRef getTarget()
     {
-        return target == null ? new NeoArtifactRef( rel.getEndNode() ) : target;
+        return target == null ? new NeoArtifactRef( rel.getEndNode(), new NeoTypeAndClassifier( rel ) ) : target;
     }
 
     @Override

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoTypeAndClassifier.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoTypeAndClassifier.java
@@ -34,8 +34,6 @@ public class NeoTypeAndClassifier
 
     private Relationship rel;
 
-    private Node node;
-
     public NeoTypeAndClassifier( final String type, final String classifier )
     {
         this.type = type == null ? "jar" : type;
@@ -52,14 +50,9 @@ public class NeoTypeAndClassifier
         this( null, null );
     }
 
-    public NeoTypeAndClassifier( Relationship rel )
+    public NeoTypeAndClassifier( final Relationship rel )
     {
         this.rel = rel;
-    }
-
-    public NeoTypeAndClassifier( Node node )
-    {
-        this.node = node;
     }
 
     @Override

--- a/drivers/neo4j-embedded/src/test/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/NeoProjectVersionRefSerializerModuleTest.java
+++ b/drivers/neo4j-embedded/src/test/java/org/commonjava/maven/atlas/graph/spi/neo4j/io/NeoProjectVersionRefSerializerModuleTest.java
@@ -35,6 +35,7 @@ import org.commonjava.maven.atlas.graph.spi.neo4j.FileNeo4jConnectionFactory;
 import org.commonjava.maven.atlas.graph.spi.neo4j.model.NeoArtifactRef;
 import org.commonjava.maven.atlas.graph.spi.neo4j.model.NeoProjectRef;
 import org.commonjava.maven.atlas.graph.spi.neo4j.model.NeoProjectVersionRef;
+import org.commonjava.maven.atlas.graph.spi.neo4j.model.NeoTypeAndClassifier;
 import org.commonjava.maven.atlas.ident.jackson.ProjectVersionRefSerializerModule;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectRef;
@@ -128,7 +129,7 @@ public class NeoProjectVersionRefSerializerModuleTest
             tx.finish();
         }
 
-        NeoArtifactRef naref = new NeoArtifactRef( node );
+        NeoArtifactRef naref = new NeoArtifactRef( node, new NeoTypeAndClassifier( "jar" ) );
         String njson = mapper.writeValueAsString( naref );
 
         assertThat( njson, equalTo( json ) );

--- a/drivers/neo4j-embedded/src/test/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoIdentitiesTest.java
+++ b/drivers/neo4j-embedded/src/test/java/org/commonjava/maven/atlas/graph/spi/neo4j/model/NeoIdentitiesTest.java
@@ -102,12 +102,12 @@ public class NeoIdentitiesTest
         ArtifactRef aref = new SimpleArtifactRef( pvr, "jar", null );
         Node node = toNode( aref );
 
-        NeoArtifactRef naref = new NeoArtifactRef( node );
+        NeoArtifactRef naref = new NeoArtifactRef( node, new NeoTypeAndClassifier( "jar" ) );
 
         assertThat( naref, equalTo( aref ) );
     }
 
-    private Node toNode( ProjectVersionRef pvr )
+    private Node toNode( final ProjectVersionRef pvr )
     {
         Transaction tx = graph.beginTx();
         Node node;


### PR DESCRIPTION
When a dependency pointing at a non-jar artifact got deserialized, the information about type and classifier was lost.

The problem was, that it tried to read those properties from the end node, but they are stored at the relationship.