### PR TITLE
Fix NotFoundExceptions and NullPointerExceptions

### DIFF
--- a/identities/src/main/java/org/commonjava/maven/atlas/ident/ref/SimpleArtifactRef.java
+++ b/identities/src/main/java/org/commonjava/maven/atlas/ident/ref/SimpleArtifactRef.java
@@ -59,7 +59,7 @@ public class SimpleArtifactRef
     public SimpleArtifactRef( final ProjectVersionRef ref, final TypeAndClassifier tc )
     {
         super( ref.getGroupId(), ref.getArtifactId(), ref.getVersionSpecRaw(), ref.getVersionStringRaw() );
-        this.tc = tc;
+        this.tc = getSimpleTypeAndClassifier( tc );
     }
 
     public SimpleArtifactRef( final String groupId, final String artifactId, final String versionSpec,
@@ -73,7 +73,19 @@ public class SimpleArtifactRef
     public <T extends ArtifactRef> SimpleArtifactRef( final ArtifactRef ref )
     {
         super( ref );
-        this.tc = ref.getTypeAndClassifier();
+        this.tc = getSimpleTypeAndClassifier( ref.getTypeAndClassifier() );
+    }
+
+    private SimpleTypeAndClassifier getSimpleTypeAndClassifier( final TypeAndClassifier tc )
+    {
+        if ( tc instanceof SimpleTypeAndClassifier )
+        {
+            return ( SimpleTypeAndClassifier ) tc;
+        }
+        else
+        {
+            return new SimpleTypeAndClassifier( tc.getType(), tc.getClassifier() );
+        }
     }
 
     @Override


### PR DESCRIPTION
After fixing of the relationship deserialization in #63 on commandline
there were some NotFoundExceptions similar to those in #55 followed by
some NullPointerExceptions somewhere in neo4j. Unfortunately Gnome
collapsed and the console got closed and the exceptions are not in indy log,
so the stacktraces are lost.

Anyway during #63 debugging I noticed that TypeAndClassifier instances
are not detached in Conversions.convertToDetachedRelationships(), so the
produced SimpleArtifactRef instances in target field contained
NeoTypeAndClassifier instances referencing RelationshipProxy. This is
obviously wrong.