### PR TITLE
Prerequisite for a cartographer fix

### DIFF
--- a/drivers/jung/src/main/java/org/commonjava/maven/atlas/graph/spi/jung/JungGraphConnection.java
+++ b/drivers/jung/src/main/java/org/commonjava/maven/atlas/graph/spi/jung/JungGraphConnection.java
@@ -1183,6 +1183,19 @@ public class JungGraphConnection
     }
 
     @Override
+    public List<ProjectRelationship<?, ?>> getRelationships( final ViewParams params, final GraphPath<?> path )
+    {
+        if ( path != null && !( path instanceof JungGraphPath ) )
+        {
+            throw new IllegalArgumentException( "Cannot get target GAV for: " + path
+                + ". This is not a JungGraphPath instance!" );
+        }
+
+        final JungGraphPath gp = (JungGraphPath) path;
+        return gp.getPathElements();
+    }
+
+    @Override
     public String getWorkspaceId()
     {
         return workspaceId;

--- a/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/FileNeo4JGraphConnection.java
+++ b/drivers/neo4j-embedded/src/main/java/org/commonjava/maven/atlas/graph/spi/neo4j/FileNeo4JGraphConnection.java
@@ -2014,6 +2014,19 @@ public class FileNeo4JGraphConnection
     }
 
     @Override
+    public List<ProjectRelationship<?, ?>> getRelationships( final ViewParams params, final GraphPath<?> path )
+    {
+        if ( path != null && !( path instanceof Neo4jGraphPath ) )
+        {
+            throw new IllegalArgumentException( "Cannot get refs for: " + path
+                + ". This is not a Neo4jGraphPathKey instance!" );
+        }
+
+        final Neo4jGraphPath gp = (Neo4jGraphPath) path;
+        return (List) convertToRelationships( gp, adminAccess );
+    }
+
+    @Override
     public GraphPath<?> createPath( final ProjectRelationship<?, ?>... rels )
     {
         if ( rels.length < 1 )

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/RelationshipGraph.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/RelationshipGraph.java
@@ -700,6 +700,11 @@ public final class RelationshipGraph
         return getConnectionInternal().getPathRefs( params, path );
     }
 
+    public List<ProjectRelationship<?, ?>> getRelationships( final GraphPath<?> path )
+    {
+        return getConnectionInternal().getRelationships( params, path );
+    }
+
     RelationshipGraphConnection getConnection()
     {
         return connection;

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractTypedFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractTypedFilter.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public abstract class AbstractTypedFilter
     implements ProjectRelationshipFilter
@@ -34,7 +35,7 @@ public abstract class AbstractTypedFilter
     //    private final Logger logger = new Logger( getClass() );
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -165,6 +166,12 @@ public abstract class AbstractTypedFilter
         //        }
 
         return false;
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return null;
     }
 
     public Set<RelationshipType> getRelationshipTypes()

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AndFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AndFilter.java
@@ -16,15 +16,19 @@
 package org.commonjava.maven.atlas.graph.filter;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public class AndFilter
     extends AbstractAggregatingFilter
 {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -52,6 +56,31 @@ public class AndFilter
         }
 
         return accepted;
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        Set<ProjectRef> excludes = null;
+        for (ProjectRelationshipFilter filter : getFilters())
+        {
+            Set<ProjectRef> filterExcludes = filter.getDepExcludes();
+            if (filterExcludes == null || filterExcludes.isEmpty())
+            {
+                excludes = null;
+                break;
+            }
+
+            if (excludes == null)
+            {
+                excludes = new HashSet<ProjectRef>(filterExcludes);
+            }
+            else
+            {
+                excludes.retainAll( filterExcludes );
+            }
+        }
+        return excludes;
     }
 
     @Override

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AnyFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AnyFilter.java
@@ -21,13 +21,14 @@ import java.util.Set;
 
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public class AnyFilter
     implements ProjectRelationshipFilter
 {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -95,6 +96,12 @@ public class AnyFilter
     public Set<RelationshipType> getAllowedTypes()
     {
         return new HashSet<RelationshipType>( Arrays.asList( RelationshipType.values() ) );
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return null;
     }
 
 }

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/BomFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/BomFilter.java
@@ -28,8 +28,8 @@ public class BomFilter
 
     private BomFilter()
     {
-        // BOMs are actually marked as concrete...somewhat counter-intuitive, 
-        // but they're structural, so managed isn't quite correct (despite 
+        // BOMs are actually marked as concrete...somewhat counter-intuitive,
+        // but they're structural, so managed isn't quite correct (despite
         // Maven's unfortunate choice for location).
         super( RelationshipType.BOM, true, false, true );
     }

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/DependencyFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/DependencyFilter.java
@@ -34,7 +34,7 @@ public class DependencyFilter
 {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -150,6 +150,11 @@ public class DependencyFilter
         }
 
         return this;
+    }
+
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return excludes;
     }
 
     public boolean isUseImpliedScopes()

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ExcludingFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ExcludingFilter.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 
 public class ExcludingFilter
@@ -65,6 +66,12 @@ public class ExcludingFilter
         {
             return new ExcludingFilter( excludedSubgraphs, childfilter );
         }
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return filter.getDepExcludes();
     }
 
     @Override

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/NoneFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/NoneFilter.java
@@ -20,13 +20,14 @@ import java.util.Set;
 
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public class NoneFilter
     implements ProjectRelationshipFilter
 {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -94,6 +95,12 @@ public class NoneFilter
     public Set<RelationshipType> getAllowedTypes()
     {
         return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return null;
     }
 
 }

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/OrFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/OrFilter.java
@@ -16,8 +16,12 @@
 package org.commonjava.maven.atlas.graph.filter;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public class OrFilter
     extends AbstractAggregatingFilter
@@ -26,7 +30,7 @@ public class OrFilter
     //    private final Logger logger = new Logger( getClass() );
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -55,6 +59,23 @@ public class OrFilter
         }
 
         return accepted;
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        Set<ProjectRef> excludes = new HashSet<ProjectRef>();
+        for (ProjectRelationshipFilter filter : getFilters())
+        {
+            Set<ProjectRef> filterExcludes = filter.getDepExcludes();
+            if (filterExcludes == null)
+            {
+                continue;
+            }
+
+            excludes.addAll( filterExcludes );
+        }
+        return excludes;
     }
 
     @Override

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/PluginRuntimeFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/PluginRuntimeFilter.java
@@ -23,13 +23,14 @@ import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
 import org.commonjava.maven.atlas.graph.rel.SimplePluginRelationship;
 import org.commonjava.maven.atlas.ident.DependencyScope;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 public class PluginRuntimeFilter
     implements ProjectRelationshipFilter
 {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
@@ -62,6 +63,12 @@ public class PluginRuntimeFilter
         }
 
         return child;
+    }
+
+    @Override
+    public Set<ProjectRef> getDepExcludes()
+    {
+        return null;
     }
 
     @Override

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ProjectRelationshipFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ProjectRelationshipFilter.java
@@ -20,12 +20,13 @@ import java.util.Set;
 
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 
 /**
  * Filter used to determine which paths in a dependency graph to traverse (or discover).
  * The full dependency graph (relation dependency, not just maven-style dependency)
  * will be QUITE extensive, so a filter should be used in NEARLY ALL cases.
- * 
+ *
  * @author jdcasey
  */
 public interface ProjectRelationshipFilter
@@ -34,26 +35,36 @@ public interface ProjectRelationshipFilter
 
     /**
      * Determine whether the given relationship should be traversed.
-     * 
+     *
      * @param rel The relationship in question
      * @return true to allow traversal, false otherwise.
      */
     boolean accept( ProjectRelationship<?, ?> rel );
 
     /**
-     * Return the filter used to handle the next wave of relationships after the 
+     * Return the filter used to handle the next wave of relationships after the
      * given one is traversed.
-     * 
+     *
      * @param parent The parent relationship for the set of relationships to which
      * the return filter from this method will be applied
-     * 
-     * @return This instance WHENEVER POSSIBLE, but possibly a different filter 
+     *
+     * @return This instance WHENEVER POSSIBLE, but possibly a different filter
      * if the relationship demands a shift in logic.
      */
     ProjectRelationshipFilter getChildFilter( ProjectRelationship<?, ?> parent );
 
     /**
-     * Retrieve a human-readable string that uniquely identifies the logic in this filter, 
+     * Provides set of dependency exclusions applied by this filter. It means only exclusions
+     * applied on dependency relationships, not subgraph exclusions, i.e. a changing set of with
+     * traversing the dependency graph, not the constant part which is provided as part of the
+     * request.
+     *
+     * @return the set of dependency exclusions, might be {@code null}
+     */
+    Set<ProjectRef> getDepExcludes();
+
+    /**
+     * Retrieve a human-readable string that uniquely identifies the logic in this filter,
      * along with any state stored in this instance.
      */
     String getLongId();

--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/spi/RelationshipGraphConnection.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/spi/RelationshipGraphConnection.java
@@ -38,7 +38,7 @@ public interface RelationshipGraphConnection
     extends Closeable
 {
 
-    /* 
+    /*
      * #########################
      * Mutations are viewless
      * #########################
@@ -61,7 +61,7 @@ public interface RelationshipGraphConnection
 
     /**
      * Add the given relationships. Skip/return those that introduce cycles.
-     * 
+     *
      * @return The set of relationships that were NOT added because they introduce cycles. NEVER null, but maybe empty.
      */
     Set<ProjectRelationship<?, ?>> addRelationships( ProjectRelationship<?, ?>... rel )
@@ -82,7 +82,7 @@ public interface RelationshipGraphConnection
     void reindex( final ProjectVersionRef ref )
         throws RelationshipGraphConnectionException;
 
-    /* 
+    /*
      * ################################################
      * Queries require a view
      * ---
@@ -171,6 +171,8 @@ public interface RelationshipGraphConnection
     ProjectVersionRef getPathTargetRef( GraphPath<?> path );
 
     List<ProjectVersionRef> getPathRefs( ViewParams params, GraphPath<?> path );
+
+    List<ProjectRelationship<?, ?>> getRelationships( ViewParams params, GraphPath<?> path );
 
     boolean isClosed();
 


### PR DESCRIPTION
We need an easy way how to get current dependency exclusions when collecting dependency graph to correctly determine, if the currently examined relationship was already seen or not. The best way to me was exposing getDepExcludes() from all filters, while I still doubt it will be enough. But at least it fixed the bug I found.