### PR TITLE
Fix classifier get error which contains dot

### DIFF
--- a/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
+++ b/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
@@ -26,15 +26,23 @@ import java.util.regex.Pattern;
 
 public class ArtifactPathInfo implements PathInfo
 {
+    private static final String GROUP_REGEX = "(([^/]+/)*[^/]+)"; // group 1 & 2
+
+    private static final String ARTIFACT_REGEX = "([^/]+)"; // group 3
+
+    private static final String VERSION_RAW_REGEX = "(([^/]+)(-SNAPSHOT)?)"; // group 4~6
 
     // regex developed at: http://fiddle.re/tvk5
     private static final String ARTIFACT_PATH_REGEX =
-        "\\/?(([^\\/]+\\/)*[^\\/]+)\\/([^\\/]+)\\/(([^\\/]+)(-SNAPSHOT)?)\\/(\\3-((\\4)|(\\5-"
-            + SnapshotUtils.RAW_REMOTE_SNAPSHOT_PART_PATTERN + "))(-([^.]+))?(\\.(.+)))";
+            "/?" + GROUP_REGEX + "/" + ARTIFACT_REGEX + "/" + VERSION_RAW_REGEX + "/(\\3-((\\4)|(\\5-"
+                    + SnapshotUtils.RAW_REMOTE_SNAPSHOT_PART_PATTERN + "))(-(.+))?(\\.(.+)))";
+            // RAW_REMOTE_SNAPSHOT_PART_PATTERN contains group 11 & 12
 
     private static final int GROUP_ID_GROUP = 1;
 
     private static final int ARTIFACT_ID_GROUP = 3;
+
+    private static final int VERSION_RAW_GROUP = 4;
 
     private static final int FILE_GROUP = 7;
 
@@ -129,12 +137,9 @@ public class ArtifactPathInfo implements PathInfo
         return isSnapshot;
     }
 
-    private SnapshotPart snapshotInfo;
-
     public synchronized SnapshotPart getSnapshotInfo()
     {
-        snapshotInfo = SnapshotUtils.extractSnapshotVersionPart( version );
-        return snapshotInfo;
+        return SnapshotUtils.extractSnapshotVersionPart(version);
     }
 
     public String getGroupId()

--- a/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
+++ b/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
@@ -54,6 +54,17 @@ public class ArtifactPathInfoTest
     {
         final String path = "/org/apache/commons/commons-lang3/3.0.0/commons-lang3-3.0.0-test.jar";
         ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "jar" ) );
+    }
+
+    @Test
+    public void matchGAWithClassifier()
+    {
+        final String path = "/org/apache/commons/commons-lang3/3.0.0.GA/commons-lang3-3.0.0.GA-test.jar";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0.GA" ) );
         assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
         assertThat( pathInfo.getType(), equalTo( "jar" ) );
     }

--- a/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
+++ b/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
@@ -49,4 +49,23 @@ public class ArtifactPathInfoTest
                                     .isSnapshot(), equalTo( false ) );
     }
 
+    @Test
+    public void matchNormalClassifier()
+    {
+        final String path = "/org/apache/commons/commons-lang3/3.0.0/commons-lang3-3.0.0-test.jar";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "jar" ) );
+    }
+
+    @Test
+    public void matchClassifierWithDot()
+    {
+        final String path =
+                "/org/uberfire/showcase-distribution-wars/7.33.0.Final-redhat-00003/showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly8.1.war";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getClassifier(), equalTo( "wildfly8.1" ) );
+        assertThat( pathInfo.getType(), equalTo( "war" ) );
+    }
+
 }


### PR DESCRIPTION
  Some maven artifact classifier can contain dot, for example: showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly8.1.war. But currently ArtifactInfoPath.parse has error to parse this type of classifier. This commit will fix the problem.