### PR TITLE
Fix classifier get error which contains dot

### DIFF
--- a/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
+++ b/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
@@ -26,15 +26,30 @@ import java.util.regex.Pattern;
 
 public class ArtifactPathInfo implements PathInfo
 {
+    private static final String GROUP_REGEX = "(([^/]+/)*[^/]+)"; // group 1~2
+
+    private static final String ARTIFACT_REGEX = "([^/]+)"; // group 3
+
+    private static final String VERSION_RAW_REGEX = "(([^/]+)(-SNAPSHOT)?)"; // group 4~6
+
+    // For classifier, if it contains dot, that means we cannot use a simple pattern which just defined by dot/non-dot way to
+    // tell, so we must define this strict way like: 1. Starts with several alphabet. 2. Following with several or non dot plus digits
+    // Here is one example: wildfly8.1.3
+    private static final String CLASSIFIER_REGEX = "(-([a-zA-Z]+\\d*(\\.\\d*)*))?"; // group 13~15
+
+    private static final String TYPE_REGEX = "(\\.(.+))"; // group 16~17
 
     // regex developed at: http://fiddle.re/tvk5
     private static final String ARTIFACT_PATH_REGEX =
-        "\\/?(([^\\/]+\\/)*[^\\/]+)\\/([^\\/]+)\\/(([^\\/]+)(-SNAPSHOT)?)\\/(\\3-((\\4)|(\\5-"
-            + SnapshotUtils.RAW_REMOTE_SNAPSHOT_PART_PATTERN + "))(-([^.]+))?(\\.(.+)))";
+            "/?" + GROUP_REGEX + "/" + ARTIFACT_REGEX + "/" + VERSION_RAW_REGEX + "/(\\3-((\\4)|(\\5-"
+                    + SnapshotUtils.RAW_REMOTE_SNAPSHOT_PART_PATTERN + "))" + CLASSIFIER_REGEX + TYPE_REGEX + ")";
+            // RAW_REMOTE_SNAPSHOT_PART_PATTERN contains group 11 & 12
 
     private static final int GROUP_ID_GROUP = 1;
 
     private static final int ARTIFACT_ID_GROUP = 3;
+
+    private static final int VERSION_RAW_GROUP = 4;
 
     private static final int FILE_GROUP = 7;
 
@@ -46,9 +61,9 @@ public class ArtifactPathInfo implements PathInfo
 
     private static final int NON_REMOTE_SNAP_TYPE_GROUP = 14;
 
-    private static final int REMOTE_SNAP_TYPE_GROUP = 16;
+    private static final int REMOTE_SNAP_TYPE_GROUP = 17;
 
-    private static final int REMOTE_SNAPSHOT_GROUP_COUNT = 16;
+    private static final int REMOTE_SNAPSHOT_GROUP_COUNT = 17;
 
     public static ArtifactPathInfo parse( final String path )
     {
@@ -129,12 +144,9 @@ public class ArtifactPathInfo implements PathInfo
         return isSnapshot;
     }
 
-    private SnapshotPart snapshotInfo;
-
     public synchronized SnapshotPart getSnapshotInfo()
     {
-        snapshotInfo = SnapshotUtils.extractSnapshotVersionPart( version );
-        return snapshotInfo;
+        return SnapshotUtils.extractSnapshotVersionPart(version);
     }
 
     public String getGroupId()

--- a/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
+++ b/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
@@ -18,7 +18,6 @@ package org.commonjava.atlas.maven.ident.util;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import org.commonjava.atlas.maven.ident.util.ArtifactPathInfo;
 import org.junit.Test;
 
 public class ArtifactPathInfoTest
@@ -47,6 +46,60 @@ public class ArtifactPathInfoTest
         final String path = "/path/to/unsigner-maven-plugin/0.2/unsigner-maven-plugin-0.2.jar";
         assertThat( ArtifactPathInfo.parse( path )
                                     .isSnapshot(), equalTo( false ) );
+    }
+
+    @Test
+    public void matchNormalClassifier()
+    {
+        String path = "/org/apache/commons/commons-lang3/3.0.0/commons-lang3-3.0.0-test.jar";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "jar" ) );
+
+        path = "/org/apache/commons/commons-lang3/3.0.0/commons-lang3-3.0.0-test.tar.gz";
+        pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "tar.gz" ) );
+    }
+
+    @Test
+    public void matchGAWithClassifier()
+    {
+        String path = "/org/apache/commons/commons-lang3/3.0.0.GA/commons-lang3-3.0.0.GA-test.jar";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0.GA" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "jar" ) );
+
+        path = "/org/apache/commons/commons-lang3/3.0.0.GA/commons-lang3-3.0.0.GA-test.tar.gz";
+        pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "3.0.0.GA" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "test" ) );
+        assertThat( pathInfo.getType(), equalTo( "tar.gz" ) );
+    }
+
+    @Test
+    public void matchClassifierWithDot()
+    {
+        String path =
+                "/org/uberfire/showcase-distribution-wars/7.33.0.Final-redhat-00003/showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly8.1.war";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getClassifier(), equalTo( "wildfly8.1" ) );
+        assertThat( pathInfo.getType(), equalTo( "war" ) );
+
+        path =
+                "/org/uberfire/showcase-distribution-wars/7.33.0.Final-redhat-00003/showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly8.2.3.0.tar.gz";
+        pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getClassifier(), equalTo( "wildfly8.2.3.0" ) );
+        assertThat( pathInfo.getType(), equalTo( "tar.gz" ) );
+
+        path =
+                "/org/uberfire/showcase-distribution-wars/7.33.0.Final-redhat-00003/showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly.8.2.3.0.tar.gz";
+        pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getClassifier(), equalTo( "wildfly.8.2.3.0" ) );
+        assertThat( pathInfo.getType(), equalTo( "tar.gz" ) );
     }
 
 }


### PR DESCRIPTION
  Some maven artifact classifier contains dot, for example: showcase-distribution-wars-7.33.0.Final-redhat-00003-wildfly8.1.war. But currently ArtifactInfoPath.parse has error to parse this type of classifier. This commit will fix the problem.
  BTW this pr also fixes the wrong type getting problem in last pr https://github.com/Commonjava/atlas/pull/85