### PR TITLE
Fix ArtifactPathInfo parse issue for project-sources.tar.gz

### DIFF
--- a/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
+++ b/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
@@ -69,6 +69,16 @@ public class ArtifactPathInfoTest
     }
 
     @Test
+    public void matchNormalClassifier2()
+    {
+        String path = "/org/jboss/modules/jboss-modules/1.5.0.Final-temporary-redhat-00033/jboss-modules-1.5.0.Final-temporary-redhat-00033-project-sources.tar.gz";
+        ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
+        assertThat( pathInfo.getVersion(), equalTo( "1.5.0.Final-temporary-redhat-00033" ) );
+        assertThat( pathInfo.getClassifier(), equalTo( "project-sources" ) );
+        assertThat( pathInfo.getType(), equalTo( "tar.gz" ) );
+    }
+
+    @Test
     public void matchGAWithClassifier()
     {
         String path = "/org/apache/commons/commons-lang3/3.0.0.GA/commons-lang3-3.0.0.GA-test.jar";


### PR DESCRIPTION
This is for MMENG-3151. Atlas can no parse path like "/org/jboss/modules/jboss-modules/1.5.0.Final-temporary-redhat-00033/jboss-modules-1.5.0.Final-temporary-redhat-00033-project-sources.tar.gz".

This is because the regex pattern does not match classifier "project-sources". It works if we use single word "sources". But when I google, it seems the classifier can be any string. We don't have a pattern to match it. 

This fix try to figure out the "type" first, and subtract it to get the classifier. It is not a ideal fix but works for most cases.