### PR TITLE
Fix pathinfo with classifier and tar.bz2 type issue

### DIFF
--- a/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
+++ b/identities/src/main/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfo.java
@@ -21,6 +21,9 @@ import org.commonjava.atlas.maven.ident.ref.SimpleArtifactRef;
 import org.commonjava.atlas.maven.ident.ref.SimpleProjectVersionRef;
 import org.commonjava.atlas.maven.ident.version.part.SnapshotPart;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,17 +46,15 @@ public class ArtifactPathInfo implements PathInfo
 
     private static final int ARTIFACT_ID_GROUP = 3;
 
-    private static final int VERSION_RAW_GROUP = 4;
-
     private static final int FILE_GROUP = 7;
 
     private static final int VERSION_GROUP = 8;
 
-    private static final String TAR_GZ = "tar.gz";
+    private static final Set<String> SPECIAL_TYPES = new HashSet<>( Arrays.asList( "tar.gz", "tar.bz2" ) );
 
     public static ArtifactPathInfo parse( final String path )
     {
-        if ( path == null || path.length() < 1 )
+        if ( path == null || path.isEmpty() )
         {
             return null;
         }
@@ -72,21 +73,25 @@ public class ArtifactPathInfo implements PathInfo
         final String v = matcher.group( VERSION_GROUP );
 
         String c = "";
-        String t;
+        String t = null;
 
         String left = matcher.group( groupCount );
         
         // The classifier can contain dots or hyphens, it is hard to separate it from type. e.g,
         // wildfly8.1.3.jar, project-sources.tar.gz, etc. We don't have a very solid pattern to match the classifier.
         // Here we use the best guess.
-        if ( left.endsWith( TAR_GZ ) )
-        {
-            t = TAR_GZ;
+        for ( String type : SPECIAL_TYPES ){
+            if ( left.endsWith( type ) )
+            {
+                t = type;
+                break;
+            }
         }
-        else
+        if ( t == null || t.isEmpty() )
         {
             t = left.substring( left.lastIndexOf( "." ) + 1 ); // Otherwise, use the simple file ext as type
         }
+
         int extLen = t.length() + 1; // plus len of "."
         int leftLen = left.length();
         if ( leftLen > extLen )

--- a/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
+++ b/identities/src/test/java/org/commonjava/atlas/maven/ident/util/ArtifactPathInfoTest.java
@@ -16,7 +16,8 @@
 package org.commonjava.atlas.maven.ident.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.commonjava.atlas.maven.ident.version.part.SnapshotPart;
@@ -79,6 +80,24 @@ public class ArtifactPathInfoTest
     }
 
     @Test
+    public void matchNormalClassifier3()
+    {
+        String path =
+                "/com/github/jomrazek/jomrazek-empty/1.0.1.redhat-00010/jomrazek-empty-1.0.1.redhat-00010-src.tar.bz2";
+        ArtifactPathInfo info = ArtifactPathInfo.parse( path );
+        assertThat( info.getVersion(), equalTo( "1.0.1.redhat-00010" ) );
+        assertThat( info.getClassifier(), equalTo( "src" ) );
+        assertThat( info.getType(), equalTo( "tar.bz2" ) );
+
+        path =
+                "/io/quarkus/platform/quarkus-google-cloud-services-bom-quarkus-platform-descriptor/2.13.7.Final-redhat-00001/quarkus-google-cloud-services-bom-quarkus-platform-descriptor-2.13.7.Final-redhat-00001-2.13.7.Final-redhat-00001.json";
+        info = ArtifactPathInfo.parse( path );
+        assertThat( info.getVersion(), equalTo( "2.13.7.Final-redhat-00001" ) );
+        assertThat( info.getClassifier(), equalTo( "2.13.7.Final-redhat-00001" ) );
+        assertThat( info.getType(), equalTo( "json" ) );
+    }
+
+    @Test
     public void matchGAWithClassifier()
     {
         String path = "/org/apache/commons/commons-lang3/3.0.0.GA/commons-lang3-3.0.0.GA-test.jar";
@@ -122,12 +141,14 @@ public class ArtifactPathInfoTest
         final String path = "/org/commonjava/maven/galley/galley-transport-httpclient/0.10.4-SNAPSHOT/galley-transport-httpclient-0.10.4-20160229.212037-2.pom";
         ArtifactPathInfo info = ArtifactPathInfo.parse( path );
         SnapshotPart snap = info.getSnapshotInfo();
-        assertTrue( "0.10.4".equals( info.getReleaseVersion() ) );
+        assertEquals( "0.10.4", info.getReleaseVersion() );
         assertTrue( snap.isRemoteSnapshot() );
-        assertTrue( "0.10.4-20160229.212037-2".equals( snap.getValue() ) );
-        assertTrue( "0.10.4-20160229.212037-2".equals( snap.getLiteral() ) );
-        assertTrue( snap.getBuildNumber() == 2 );
-        assertTrue( "20160229".equals( new SimpleDateFormat( "yyyyMMdd" ).format( snap.getTimestamp() ) ) );
+        assertEquals( "0.10.4-20160229.212037-2", snap.getValue() );
+        assertEquals( "0.10.4-20160229.212037-2", snap.getLiteral() );
+        assertEquals( 2, snap.getBuildNumber() );
+        assertEquals( "20160229", new SimpleDateFormat( "yyyyMMdd" ).format( snap.getTimestamp() ) );
     }
+
+
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
   </scm>
 
   <properties>
+    <javaVersion>11</javaVersion>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <projectEmail>nos-devel@redhat.com</projectEmail>
     <pmd.skip>true</pmd.skip>
@@ -141,8 +142,8 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>${javaVersion}</source>
+            <target>${javaVersion}</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
  Seems a path contains classifier and the type of tar.bz2 will cause
  parse issue for pathinfo, we will treat it as special case like the
  tar.gz too.
  And also changes the java version to 11 and some code style issue.